### PR TITLE
fix: remove websocket options in docker command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN  apt-get update \
   && rm -rf /tmp/*
 
 EXPOSE 8000
-EXPOSE 25482
 
 VOLUME ["/data"]
 CMD ["omnidb-server","-H","0.0.0.0","-p","8000","-d","/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 8000
 EXPOSE 25482
 
 VOLUME ["/data"]
-CMD ["omnidb-server","-H","0.0.0.0","-p","8000","-w","25482","-d","/data"]
+CMD ["omnidb-server","-H","0.0.0.0","-p","8000","-d","/data"]


### PR DESCRIPTION
Change cmd in Dockerfile from
```
CMD ["omnidb-server","-H","0.0.0.0","-p","8000","-w","25482","-d","/data"]
```
to
```
CMD ["omnidb-server","-H","0.0.0.0","-p","8000","-d","/data"]
```

and remove `EXPOSE 25482`